### PR TITLE
feat: 결제 내역을 일별 그룹화하여 반환 및 리스트로 나오게 수정 및 일별 총 결제 금액 추가.

### DIFF
--- a/backend/src/main/java/CardRecommendService/memberCard/DailyCardHistoryResponse.java
+++ b/backend/src/main/java/CardRecommendService/memberCard/DailyCardHistoryResponse.java
@@ -1,0 +1,17 @@
+package CardRecommendService.memberCard;
+
+import CardRecommendService.cardHistory.CardHistoryResponse;
+
+import java.time.LocalDate;
+import java.util.List;
+
+
+public record DailyCardHistoryResponse(
+
+        LocalDate date,
+        List<CardHistoryResponse> paymentHistories,
+        int totalAmount
+
+
+) {
+}

--- a/backend/src/main/java/CardRecommendService/memberCard/MemberCardController.java
+++ b/backend/src/main/java/CardRecommendService/memberCard/MemberCardController.java
@@ -40,17 +40,27 @@ public class MemberCardController {
 
     }
 
-    // 멤버 카드와 결제 내역을 조회, 결제 내역을 월 단위로 필터링
     @GetMapping("/membercard/cards/history")
-    public Map<LocalDate, List<CardHistoryResponse>> getCardsHistories(
+    public List<DailyCardHistoryResponse> getCardsHistories(
             @RequestParam List<Long> memberCardIds,
             @RequestParam int month) {
-
         Month convertedMonth = Month.of(month); // int를 Month로 변환
 
         return memberCardService.getCardsHistories(memberCardIds, convertedMonth);
-
     }
+
+
+//    // 멤버 카드와 결제 내역을 조회, 결제 내역을 월 단위로 필터링
+//    @GetMapping("/membercard/cards/history")
+//    public Map<LocalDate, List<CardHistoryResponse>> getCardsHistories(
+//            @RequestParam List<Long> memberCardIds,
+//            @RequestParam int month) {
+//
+//        Month convertedMonth = Month.of(month); // int를 Month로 변환
+//
+//        return memberCardService.getCardsHistories(memberCardIds, convertedMonth);
+//
+//    }
 
 
 }


### PR DESCRIPTION
예시 :
{
        "date": "2025-03-01",
        "paymentHistories": [
            {
                "cardName": "넌이제파산",
                "cardCrop": "고금리은행",
                "storeName": "스타벅스",
                "amount": 1000,
                "paymentDatetime": "2025-03-01T14:30:00",
                "category": "커피제과"
            },
            {
                "cardName": "넌이제파산",
                "cardCrop": "고금리은행",
                "storeName": "파리바게트",
                "amount": 5000,
                "paymentDatetime": "2025-03-01T09:15:00",
                "category": "커피제과"
            },
            {
                "cardName": "넌이제파산",
                "cardCrop": "고금리은행",
                "storeName": "BBQ치킨",
                "amount": 12000,
                "paymentDatetime": "2025-03-01T19:00:00",
                "category": "음식점"
            }
        ],
        "totalAmount": 18000
    },